### PR TITLE
feat(command): Enhance isSlashCommand to exclude comments

### DIFF
--- a/packages/cli/src/ui/components/SuggestionsDisplay.tsx
+++ b/packages/cli/src/ui/components/SuggestionsDisplay.tsx
@@ -7,6 +7,7 @@
 import { Box, Text } from 'ink';
 import { Colors } from '../colors.js';
 import { PrepareLabel } from './PrepareLabel.js';
+import { isSlashCommand } from '../utils/commandUtils.js';
 export interface Suggestion {
   label: string;
   value: string;
@@ -52,7 +53,7 @@ export function SuggestionsDisplay({
   );
   const visibleSuggestions = suggestions.slice(startIndex, endIndex);
 
-  const isSlashCommandMode = userInput.startsWith('/');
+  const isSlashCommandMode = isSlashCommand(userInput);
   let commandNameWidth = 0;
 
   if (isSlashCommandMode) {

--- a/packages/cli/src/ui/components/messages/UserMessage.tsx
+++ b/packages/cli/src/ui/components/messages/UserMessage.tsx
@@ -8,6 +8,7 @@ import React from 'react';
 import { Text, Box } from 'ink';
 import { Colors } from '../../colors.js';
 import { SCREEN_READER_USER_PREFIX } from '../../constants.js';
+import { isSlashCommand } from '../../utils/commandUtils.js';
 
 interface UserMessageProps {
   text: string;
@@ -16,10 +17,10 @@ interface UserMessageProps {
 export const UserMessage: React.FC<UserMessageProps> = ({ text }) => {
   const prefix = '> ';
   const prefixWidth = prefix.length;
-  const isSlashCommand = text.startsWith('/');
+  const isCommand = isSlashCommand(text);
 
-  const textColor = isSlashCommand ? Colors.AccentPurple : Colors.Gray;
-  const borderColor = isSlashCommand ? Colors.AccentPurple : Colors.Gray;
+  const textColor = isCommand ? Colors.AccentPurple : Colors.Gray;
+  const borderColor = isCommand ? Colors.AccentPurple : Colors.Gray;
 
   return (
     <Box

--- a/packages/cli/src/ui/hooks/useCommandCompletion.test.ts
+++ b/packages/cli/src/ui/hooks/useCommandCompletion.test.ts
@@ -517,4 +517,83 @@ describe('useCommandCompletion', () => {
       );
     });
   });
+
+  describe('prompt completion filtering', () => {
+    it('should not trigger prompt completion for JavaScript comments', async () => {
+      const mockConfig = {
+        getEnablePromptCompletion: () => true,
+      } as Config;
+
+      const { result } = renderHook(() => {
+        const textBuffer = useTextBufferForTest(
+          '// This is a JavaScript comment',
+        );
+        const completion = useCommandCompletion(
+          textBuffer,
+          testDirs,
+          testRootDir,
+          [],
+          mockCommandContext,
+          false,
+          mockConfig,
+        );
+        return { ...completion, textBuffer };
+      });
+
+      // Should not trigger prompt completion for comments
+      expect(result.current.suggestions.length).toBe(0);
+    });
+
+    it('should not trigger prompt completion for C-style comments', async () => {
+      const mockConfig = {
+        getEnablePromptCompletion: () => true,
+      } as Config;
+
+      const { result } = renderHook(() => {
+        const textBuffer = useTextBufferForTest(
+          '/* This is a block comment */',
+        );
+        const completion = useCommandCompletion(
+          textBuffer,
+          testDirs,
+          testRootDir,
+          [],
+          mockCommandContext,
+          false,
+          mockConfig,
+        );
+        return { ...completion, textBuffer };
+      });
+
+      // Should not trigger prompt completion for comments
+      expect(result.current.suggestions.length).toBe(0);
+    });
+
+    it('should trigger prompt completion for regular text when enabled', async () => {
+      const mockConfig = {
+        getEnablePromptCompletion: () => true,
+      } as Config;
+
+      const { result } = renderHook(() => {
+        const textBuffer = useTextBufferForTest(
+          'This is regular text that should trigger completion',
+        );
+        const completion = useCommandCompletion(
+          textBuffer,
+          testDirs,
+          testRootDir,
+          [],
+          mockCommandContext,
+          false,
+          mockConfig,
+        );
+        return { ...completion, textBuffer };
+      });
+
+      // This test verifies that comments are filtered out while regular text is not
+      expect(result.current.textBuffer.text).toBe(
+        'This is regular text that should trigger completion',
+      );
+    });
+  });
 });

--- a/packages/cli/src/ui/hooks/useCommandCompletion.tsx
+++ b/packages/cli/src/ui/hooks/useCommandCompletion.tsx
@@ -136,7 +136,7 @@ export function useCommandCompletion(
       if (
         isPromptCompletionEnabled &&
         trimmedText.length >= PROMPT_COMPLETION_MIN_LENGTH &&
-        !trimmedText.startsWith('/') &&
+        !isSlashCommand(trimmedText) &&
         !trimmedText.includes('@')
       ) {
         return {

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -1096,6 +1096,42 @@ describe('useGeminiStream', () => {
         );
       });
     });
+
+    it('should not call handleSlashCommand for JavaScript comments', async () => {
+      const { result, mockSendMessageStream: localMockSendMessageStream } =
+        renderTestHook();
+
+      await act(async () => {
+        await result.current.submitQuery('// This is a JavaScript comment');
+      });
+
+      await waitFor(() => {
+        expect(mockHandleSlashCommand).not.toHaveBeenCalled();
+        expect(localMockSendMessageStream).toHaveBeenCalledWith(
+          '// This is a JavaScript comment',
+          expect.any(AbortSignal),
+          expect.any(String),
+        );
+      });
+    });
+
+    it('should not call handleSlashCommand for C-style comments', async () => {
+      const { result, mockSendMessageStream: localMockSendMessageStream } =
+        renderTestHook();
+
+      await act(async () => {
+        await result.current.submitQuery('/* This is a block comment */');
+      });
+
+      await waitFor(() => {
+        expect(mockHandleSlashCommand).not.toHaveBeenCalled();
+        expect(localMockSendMessageStream).toHaveBeenCalledWith(
+          '/* This is a block comment */',
+          expect.any(AbortSignal),
+          expect.any(String),
+        );
+      });
+    });
   });
 
   describe('Memory Refresh on save_memory', () => {

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -37,7 +37,7 @@ import {
   SlashCommandProcessorResult,
   ToolCallStatus,
 } from '../types.js';
-import { isAtCommand } from '../utils/commandUtils.js';
+import { isAtCommand, isSlashCommand } from '../utils/commandUtils.js';
 import { useShellCommandProcessor } from './shellCommandProcessor.js';
 import { handleAtCommand } from './atCommandProcessor.js';
 import { findLastSafeSplitPoint } from '../utils/markdownUtilities.js';
@@ -244,8 +244,10 @@ export const useGeminiStream = (
         onDebugMessage(`User query: '${trimmedQuery}'`);
         await logger?.logMessage(MessageSenderType.USER, trimmedQuery);
 
-        // Handle UI-only commands first
-        const slashCommandResult = await handleSlashCommand(trimmedQuery);
+        // Handle UI-only commands first (only if it's actually a slash command)
+        const slashCommandResult = isSlashCommand(trimmedQuery)
+          ? await handleSlashCommand(trimmedQuery)
+          : false;
 
         if (slashCommandResult) {
           switch (slashCommandResult.type) {

--- a/packages/cli/src/ui/hooks/usePromptCompletion.ts
+++ b/packages/cli/src/ui/hooks/usePromptCompletion.ts
@@ -12,6 +12,7 @@ import {
 } from '@google/gemini-cli-core';
 import { Content, GenerateContentConfig } from '@google/genai';
 import { TextBuffer } from '../components/shared/text-buffer.js';
+import { isSlashCommand } from '../utils/commandUtils.js';
 
 export const PROMPT_COMPLETION_MIN_LENGTH = 5;
 export const PROMPT_COMPLETION_DEBOUNCE_MS = 250;
@@ -81,7 +82,7 @@ export function usePromptCompletion({
     if (
       trimmedText.length < PROMPT_COMPLETION_MIN_LENGTH ||
       !geminiClient ||
-      trimmedText.startsWith('/') ||
+      isSlashCommand(trimmedText) ||
       trimmedText.includes('@') ||
       !isPromptCompletionEnabled
     ) {
@@ -237,7 +238,7 @@ export function usePromptCompletion({
     const trimmedText = buffer.text.trim();
     return (
       trimmedText.length >= PROMPT_COMPLETION_MIN_LENGTH &&
-      !trimmedText.startsWith('/') &&
+      !isSlashCommand(trimmedText) &&
       !trimmedText.includes('@')
     );
   }, [buffer.text, isPromptCompletionEnabled, isCursorAtEnd]);

--- a/packages/cli/src/ui/utils/commandUtils.test.ts
+++ b/packages/cli/src/ui/utils/commandUtils.test.ts
@@ -101,6 +101,20 @@ describe('commandUtils', () => {
       expect(isSlashCommand('path/to/file')).toBe(false);
       expect(isSlashCommand(' /help')).toBe(false);
     });
+
+    it('should return false for JavaScript comments starting with //', () => {
+      expect(isSlashCommand('// This is a comment')).toBe(false);
+      expect(isSlashCommand('// check if variants base info all filled.')).toBe(
+        false,
+      );
+      expect(isSlashCommand('//comment without space')).toBe(false);
+    });
+
+    it('should return false for C-style comments starting with /*', () => {
+      expect(isSlashCommand('/* This is a block comment */')).toBe(false);
+      expect(isSlashCommand('/*\n * Multi-line comment\n */')).toBe(false);
+      expect(isSlashCommand('/*comment without space*/')).toBe(false);
+    });
   });
 
   describe('copyToClipboard', () => {

--- a/packages/cli/src/ui/utils/commandUtils.ts
+++ b/packages/cli/src/ui/utils/commandUtils.ts
@@ -20,12 +20,28 @@ export const isAtCommand = (query: string): boolean =>
 
 /**
  * Checks if a query string potentially represents an '/' command.
- * It triggers if the query starts with '/'
+ * It triggers if the query starts with '/' but excludes code comments like '//' and '/*'.
  *
  * @param query The input query string.
  * @returns True if the query looks like an '/' command, false otherwise.
  */
-export const isSlashCommand = (query: string): boolean => query.startsWith('/');
+export const isSlashCommand = (query: string): boolean => {
+  if (!query.startsWith('/')) {
+    return false;
+  }
+
+  // Exclude JavaScript/C++ style comments that start with '//'
+  if (query.startsWith('//')) {
+    return false;
+  }
+
+  // Exclude C-style block comments that start with '/*'
+  if (query.startsWith('/*')) {
+    return false;
+  }
+
+  return true;
+};
 
 // Copies a string snippet to the clipboard for different platforms
 export const copyToClipboard = async (text: string): Promise<void> => {


### PR DESCRIPTION
## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->

## Sourcery 总结

增强斜杠命令检测功能，使其忽略 JS 和 C 风格的注释，更新相关组件和钩子以使用新逻辑，并添加测试以验证注释不再触发斜杠命令或提示补全。

增强功能：
- 扩展 `isSlashCommand` 以排除以 `//` 或 `/*` 开头的查询
- 在提示补全、命令补全、流处理和 UI 组件中，用 `isSlashCommand` 替换直接的斜杠检测 (`startsWith('/')`)

测试：
- 添加单元测试，以确保 `useCommandCompletion` 和 `useGeminiStream` 中的 JavaScript 和 C 风格注释不会触发斜杠命令和提示补全
- 为 `isSlashCommand` 添加测试，以验证各种注释格式的排除情况

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhance slash command detection to ignore JS and C-style comments, update related components and hooks to use the new logic, and add tests to verify that comments no longer trigger slash commands or prompt completions

Enhancements:
- Extend isSlashCommand to exclude queries starting with '//' or '/*'
- Replace direct slash detection (startsWith('/')) with isSlashCommand in prompt completion, command completion, stream handling, and UI components

Tests:
- Add unit tests to ensure slash commands and prompt completions are not triggered for JavaScript and C-style comments in useCommandCompletion and useGeminiStream
- Add tests for isSlashCommand to validate exclusion of various comment formats

</details>